### PR TITLE
Fixed next free ID on clusters

### DIFF
--- a/lxc_privilege_converter.sh
+++ b/lxc_privilege_converter.sh
@@ -104,7 +104,7 @@ select_target_storage() {
 # find the next free ID
 find_next_free_id() {
     local existing_ids
-    existing_ids=$({ pct list | awk 'NR>1 {print $1}'; qm list | awk 'NR>1 {print $1}'; } | sort -un)
+    existing_ids=$({ pvesh get /cluster/resources --type vm --output-format text | awk -F'│' '/lxc|qemu/ { print $2 }' | awk -F'/' '{ print $2 }' | tr -d ' '; } | sort -un)
 
     local id=100
     while true; do


### PR DESCRIPTION
The `find_next_free_id()` function only works for single PVE-hosts but not on clusters. Which causes the conversion most likely to fail, when the first free ID on the local host is used (which is most likely already in use on another host).

This fix uses `pvesh` instead of `pct` to get the existing ID's from all hosts not only the local ones.