### PR TITLE
Fix README spelling

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -9,7 +9,7 @@ Convert LXC containers between privileged and unprivileged modes in Proxmox VE. 
 - Interactive menu for container and storage selection.
 - Validates new container ID against all cluster VMs and LXCs.
 - Automatic vzdump backup and restore / PBS backup and restore. 
-- Detects and switches privilege mode from unprivileged to priviliged and vise versa.
+- Detects and switches privilege mode from unprivileged to privileged and vice versa.
 - Handles Proxmox Backup Server (PBS) and local Backup Storage for the conversion Temp Files.
 - Optional shutdown/start logic for containers, including force kill.
 - Prompts for cleanup of backup files after conversion.


### PR DESCRIPTION
## Summary
- fix misspelling of "privileged" and "vice versa" in README

## Testing
- `grep -n 'privileged' README.MD`


------
https://chatgpt.com/codex/tasks/task_e_687d55325fb883228b93f20c59859e3d